### PR TITLE
Remove junit and commons-io from the compile configuration

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,8 +18,6 @@ dependencies {
     compile gradleApi()
     compile "org.gradle:gradle-tooling-api:${gradle.gradleVersion}"
 
-    runtime 'org.slf4j:slf4j-simple:1.6.6'
-
     // just here to test that dependencies of build logic can be used in a functional test
     buildLogic "commons-io:commons-io:2.4"
     testCompile configurations.buildLogic

--- a/build.gradle
+++ b/build.gradle
@@ -11,6 +11,7 @@ repositories {
 
 configurations {
     buildLogic
+    testCompile.extendsFrom buildLogic
 }
 
 dependencies {
@@ -20,7 +21,6 @@ dependencies {
 
     // just here to test that dependencies of build logic can be used in a functional test
     buildLogic "commons-io:commons-io:2.4"
-    testCompile configurations.buildLogic
 
     testCompile "junit:junit:4.10"
     testCompile "org.spockframework:spock-core:0.7-groovy-1.8", {

--- a/build.gradle
+++ b/build.gradle
@@ -9,18 +9,22 @@ repositories {
     }
 }
 
+configurations {
+    buildLogic
+}
+
 dependencies {
     compile localGroovy()
     compile gradleApi()
-
-    // just here to test that dependencies of build logic can be used in a functional test
-    compile "commons-io:commons-io:2.4"
-
     compile "org.gradle:gradle-tooling-api:${gradle.gradleVersion}"
+
     runtime 'org.slf4j:slf4j-simple:1.6.6'
 
-    compile "junit:junit:4.10"
+    // just here to test that dependencies of build logic can be used in a functional test
+    buildLogic "commons-io:commons-io:2.4"
+    testCompile configurations.buildLogic
 
+    testCompile "junit:junit:4.10"
     testCompile "org.spockframework:spock-core:0.7-groovy-1.8", {
         exclude module: "groovy-all"
     }


### PR DESCRIPTION
Remove junit and commons-io from the compile configuration.
Remove unneeded slf4j-simple from the runtime configuration.
Add a 'buildLogic' configuration used to test that dependencies of build logic can be used in a functional test.
This should ease the path towards publishing gradle-test-kit artifact.
